### PR TITLE
dpu: llvm: match more store immediates

### DIFF
--- a/llvm/lib/Target/DPU/DPUISelDAGToDAG.cpp
+++ b/llvm/lib/Target/DPU/DPUISelDAGToDAG.cpp
@@ -15,12 +15,15 @@
 #include "DPUTargetMachine.h"
 
 #include "DPUISelLowering.h"
+#include "llvm/CodeGen/ISDOpcodes.h"
 #include "llvm/CodeGen/MachineConstantPool.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/CodeGen/SelectionDAGISel.h"
+#include "llvm/CodeGen/SelectionDAGNodes.h"
+#include "llvm/IR/GlobalObject.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
@@ -80,6 +83,8 @@ private:
   // Checks whether the target of a store operation is the requested address
   // space.
   bool IsAStoreToAddrSpace(SDNode *Node, unsigned int AddrSpace) const;
+
+  bool IsGlobalAddrInImmediateSection(SDNode *Node) const;
 
   void processFunctionAfterISel(MachineFunction &MF);
 
@@ -344,6 +349,31 @@ bool DPUDAGToDAGISel::IsAStoreToAddrSpace(SDNode *Node,
     }
   }
   return false;
+}
+
+bool DPUDAGToDAGISel::IsGlobalAddrInImmediateSection(SDNode *Node) const {
+    if (Node->getOpcode() != DPUISD::Wrapper) {
+        return false;
+    }
+
+    SDValue Value = Node->getOperand(0);
+
+    GlobalAddressSDNode *AddrNode = cast<GlobalAddressSDNode>(Value);
+
+    if (!AddrNode) {
+        return false;
+    }
+
+    const auto GO = AddrNode->getGlobal()->getBaseObject();
+    const auto *GVA = dyn_cast<GlobalVariable>(GO);
+
+    if (!GVA->hasSection()) {
+        return false;
+    }
+
+    StringRef Section = GVA->getSection();
+
+    return Section.startswith(".data.immediate_memory");
 }
 
 void DPUDAGToDAGISel::Select(SDNode *Node) {

--- a/llvm/lib/Target/DPU/DPUISelDAGToDAG.cpp
+++ b/llvm/lib/Target/DPU/DPUISelDAGToDAG.cpp
@@ -352,28 +352,28 @@ bool DPUDAGToDAGISel::IsAStoreToAddrSpace(SDNode *Node,
 }
 
 bool DPUDAGToDAGISel::IsGlobalAddrInImmediateSection(SDNode *Node) const {
-    if (Node->getOpcode() != DPUISD::Wrapper) {
-        return false;
-    }
+  if (Node->getOpcode() != DPUISD::Wrapper) {
+    return false;
+  }
 
-    SDValue Value = Node->getOperand(0);
+  SDValue Value = Node->getOperand(0);
 
-    GlobalAddressSDNode *AddrNode = cast<GlobalAddressSDNode>(Value);
+  GlobalAddressSDNode *AddrNode = cast<GlobalAddressSDNode>(Value);
 
-    if (!AddrNode) {
-        return false;
-    }
+  if (!AddrNode) {
+    return false;
+  }
 
-    const auto GO = AddrNode->getGlobal()->getBaseObject();
-    const auto *GVA = dyn_cast<GlobalVariable>(GO);
+  const auto GO = AddrNode->getGlobal()->getBaseObject();
+  const auto *GVA = dyn_cast<GlobalVariable>(GO);
 
-    if (!GVA->hasSection()) {
-        return false;
-    }
+  if (!GVA->hasSection()) {
+    return false;
+  }
 
-    StringRef Section = GVA->getSection();
+  StringRef Section = GVA->getSection();
 
-    return Section.startswith(".data.immediate_memory");
+  return Section.startswith(".data.immediate_memory");
 }
 
 void DPUDAGToDAGISel::Select(SDNode *Node) {

--- a/llvm/lib/Target/DPU/DPUInstrInfo.td
+++ b/llvm/lib/Target/DPU/DPUInstrInfo.td
@@ -87,6 +87,10 @@ class wram_store_frag<PatFrag base_store> : PatFrag<(ops node:$val, node:$ptr), 
     return IsAStoreToAddrSpace(N, DPUADDR_SPACE::WRAM);
 }]>;
 
+def IsInImmediateSection: PatFrag<(ops node:$sym), (DPUWrapper node:$sym), [{
+    return IsGlobalAddrInImmediateSection(N);
+}]>;
+
 multiclass WramLoadXPat<ImmOperand LdTy, PatFrag LoadOp, DPUInstruction Inst> {
   def : Pat<(LdTy (wram_load_frag<LoadOp> SimpleRegOrCst:$ra)), (Inst SimpleRegOrCst:$ra, 0)>;
   def : Pat<(LdTy (wram_load_frag<LoadOp> AddrFI:$ra)), (Inst AddrFI:$ra, 0)>;
@@ -135,13 +139,16 @@ multiclass WramStoreSub64Pat<PatFrag StoreOp, DPUInstruction Inst> {
 }
 
 multiclass WramStoreImmPat<PatFrag WramStoreImmOp, DPUInstruction Inst, ImmOperand StTy> {
+  def : Pat<(WramStoreImmOp (StTy:$imm), (IsInImmediateSection i32:$addr)), (Inst ZERO, i32:$addr, StTy:$imm)>;
   def : Pat<(WramStoreImmOp (StTy:$imm), SimpleRegOrCst:$ra), (Inst SimpleRegOrCst:$ra, 0, StTy:$imm)>;
   def : Pat<(WramStoreImmOp (StTy:$imm), AddrFI:$ra), (Inst AddrFI:$ra, 0, StTy:$imm)>;
+  def : Pat<(WramStoreImmOp (StTy:$imm), (add SimpleRegOrCst:$ra, (IsInImmediateSection i32:$off))), (Inst SimpleRegOrCst:$ra, i32:$off, StTy:$imm)>;
   def : Pat<(WramStoreImmOp (StTy:$imm), (add SimpleRegOrCst:$ra, s12_imm:$off)), (Inst SimpleRegOrCst:$ra, s12_imm:$off, StTy:$imm)>;
+  def : Pat<(WramStoreImmOp (StTy:$imm), (add AddrFI:$ra, (IsInImmediateSection i32:$off))), (Inst AddrFI:$ra, i32:$off, StTy:$imm)>;
   def : Pat<(WramStoreImmOp (StTy:$imm), (add AddrFI:$ra, s12_imm:$off)), (Inst AddrFI:$ra, s12_imm:$off, StTy:$imm)>;
+  def : Pat<(WramStoreImmOp (StTy:$imm), (IsOrAdd AddrFI:$ra, (IsInImmediateSection i32:$off))), (Inst AddrFI:$ra, i32:$off, StTy:$imm)>;
   def : Pat<(WramStoreImmOp (StTy:$imm), (IsOrAdd SimpleRegOrCst:$ra, s12_imm:$off)), (Inst SimpleRegOrCst:$ra, s12_imm:$off, StTy:$imm)>;
   def : Pat<(WramStoreImmOp (StTy:$imm), (IsOrAdd AddrFI:$ra, s12_imm:$off)), (Inst AddrFI:$ra, s12_imm:$off, StTy:$imm)>;
-  // todo: we could add the DPUWrapper Patterns here, if we could check that $off is at the start of the memory (in section ".data.immediate_memory")
 }
 
 defm : WramLoadPat<zextloadi8, LBUrri, LBU_Urri>;


### PR DESCRIPTION
Global addresses in a section starting with '.data.immediate_memory' are eligible for the store immediate instructions.

Fix #6