### PR TITLE
dpu: llvm: Fix store immediate with frame index

### DIFF
--- a/llvm/lib/Target/DPU/DPUInstrInfo.td
+++ b/llvm/lib/Target/DPU/DPUInstrInfo.td
@@ -183,9 +183,7 @@ multiclass WramStoreImmPat<PatFrag WramStoreImmOp, DPUInstruction Inst, ImmOpera
   def : Pat<(wram_store_frag<WramStoreImmOp> (StTy:$imm), AddrFI:$ra), (Inst AddrFI:$ra, 0, StTy:$imm)>;
   def : Pat<(wram_store_frag<WramStoreImmOp> (StTy:$imm), (add SimpleRegOrCst:$ra, (IsInImmediateSection i32:$off))), (Inst SimpleRegOrCst:$ra, i32:$off, StTy:$imm)>;
   def : Pat<(wram_store_frag<WramStoreImmOp> (StTy:$imm), (add SimpleRegOrCst:$ra, s12_imm:$off)), (Inst SimpleRegOrCst:$ra, s12_imm:$off, StTy:$imm)>;
-  def : Pat<(wram_store_frag<WramStoreImmOp> (StTy:$imm), (add AddrFI:$ra, (IsInImmediateSection i32:$off))), (Inst AddrFI:$ra, i32:$off, StTy:$imm)>;
   def : Pat<(wram_store_frag<WramStoreImmOp> (StTy:$imm), (add AddrFI:$ra, s12_imm:$off)), (Inst AddrFI:$ra, s12_imm:$off, StTy:$imm)>;
-  def : Pat<(wram_store_frag<WramStoreImmOp> (StTy:$imm), (IsOrAdd AddrFI:$ra, (IsInImmediateSection i32:$off))), (Inst AddrFI:$ra, i32:$off, StTy:$imm)>;
   def : Pat<(wram_store_frag<WramStoreImmOp> (StTy:$imm), (IsOrAdd SimpleRegOrCst:$ra, s12_imm:$off)), (Inst SimpleRegOrCst:$ra, s12_imm:$off, StTy:$imm)>;
   def : Pat<(wram_store_frag<WramStoreImmOp> (StTy:$imm), (IsOrAdd AddrFI:$ra, s12_imm:$off)), (Inst AddrFI:$ra, s12_imm:$off, StTy:$imm)>;
 }

--- a/llvm/lib/Target/DPU/DPURegisterInfo.h
+++ b/llvm/lib/Target/DPU/DPURegisterInfo.h
@@ -30,12 +30,24 @@ public:
 
   void eliminateFrameIndex(MachineBasicBlock::iterator II, int SPAdj,
                            unsigned FIOperandNum,
-                           RegScavenger *RS) const override;
+                           RegScavenger *RS = nullptr) const override;
 
   Register getFrameRegister(const MachineFunction &MF) const override;
 
   const uint32_t *getCallPreservedMask(const MachineFunction &MF,
                                        CallingConv::ID) const override;
+
+  bool requiresRegisterScavenging(const MachineFunction &MF) const override {
+    return true;
+  }
+
+  bool requiresFrameIndexScavenging(const MachineFunction &MF) const override {
+    return true;
+  }
+
+  bool trackLivenessAfterRegAlloc(const MachineFunction &MF) const override {
+    return true;
+  }
 };
 } // namespace llvm
 #endif


### PR DESCRIPTION
Check offset constraints in `eliminateFrameIndex`.

@vpalatin Not sure if we want to merge this before the release. The bug can only happen with big stacks (offset need to be bigger than 2048).