### PR TITLE
dpu: llvm: removing chain from LslAdd node

### DIFF
--- a/llvm/lib/Target/DPU/DPUInstrInfo.td
+++ b/llvm/lib/Target/DPU/DPUInstrInfo.td
@@ -32,7 +32,7 @@ def SDT_Lsr1            : SDNode<"DPUISD::Lsr1" , SDT_SHIFT, [SDNPHasChain]>;
 def SDT_Lsr1x           : SDNode<"DPUISD::Lsr1x", SDT_SHIFT, [SDNPHasChain]>;
 
 def SDT_SHIFT_ADD : SDTypeProfile<1, 3, [SDTCisInt<0>, SDTCisInt<1>, SDTCisInt<2>, SDTCisInt<3>]>;
-def SDT_Lsl_add         : SDNode<"DPUISD::LslAdd", SDT_SHIFT_ADD, [SDNPHasChain]>;
+def SDT_Lsl_add         : SDNode<"DPUISD::LslAdd", SDT_SHIFT_ADD, []>;
 
 def SDT_Mul8            : SDTypeProfile<1, 2, [SDTCisSameAs<1, 2>]>;
 def SDT_Mul8UU          : SDNode<"DPUISD::MUL8_UU", SDT_Mul8, [SDNPInGlue]>;

--- a/llvm/lib/Target/DPU/DPUTargetLowering.cpp
+++ b/llvm/lib/Target/DPU/DPUTargetLowering.cpp
@@ -1870,7 +1870,7 @@ SDValue DPUTargetLowering::LowerDMA(SDValue Op, SelectionDAG &DAG,
                               DAG.getConstant(3, dl, MVT::i32));
     tmp =
         DAG.getNode(ISD::SUB, dl, raVT, tmp, DAG.getConstant(1, dl, MVT::i32));
-    ra = DAG.getNode(DPUISD::LslAdd, dl, raVT, chain, ra, tmp,
+    ra = DAG.getNode(DPUISD::LslAdd, dl, raVT, ra, tmp,
                      DAG.getConstant(24, dl, MVT::i32));
     immDma = DAG.getConstant(0, dl, MVT::i32);
   }


### PR DESCRIPTION
In debug mode, an assertion was failing on the LslAdd node