### PR TITLE
lldb: scripts: Fix struct dpu_slice_target layout

### DIFF
--- a/lldb/scripts/dpu/dpu_commands.py
+++ b/lldb/scripts/dpu/dpu_commands.py
@@ -267,7 +267,7 @@ def dpu_attach(debugger, command, result, internal_dict):
         .GetValueAsUnsigned()
     slice_target_dpu_group_id = slice_target.GetChildMemberWithName("dpu_id") \
         .GetValueAsUnsigned()
-    slice_target = (slice_target_type << 32) + slice_target_dpu_group_id
+    slice_target = (slice_target_dpu_group_id << 32) + slice_target_type
 
     pid = compute_dpu_pid(region_id, rank_id, slice_id, dpu_id)
 


### PR DESCRIPTION
The dpu_slice_target structure is defined:

struct dpu_slice_target {
    enum dpu_slice_target_type type;
    union {
        dpu_member_id_t dpu_id;
        dpu_group_id_t group_id;
    };
};

so the LSB is the type, not the dpu_id/group_id.