### PR TITLE
lldb: support new rank device name

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/dpu/dpu_list/TestDpuList.py
+++ b/lldb/packages/Python/lldbsuite/test/dpu/dpu_list/TestDpuList.py
@@ -61,7 +61,7 @@ class DpuListTestCase(TestBase):
         process.GetSelectedThread().SetSelectedFrame(1)
         dpu_list = dpu_commands.dpu_list(self.dbg, "", None, None)
 
-        for (dpu_addr, rank_id, region_id, slice_id, dpu_id,
+        for (dpu_addr, rank_id, slice_id, dpu_id,
              dpu_status, dpu_program) in dpu_list:
             if dpu_status == "RUNNING":
                 self.assertTrue(dpu_program == dpu_exe)


### PR DESCRIPTION
Regions are made up of a single rank, so rank ID is always 0. We decided to get rid of the region ID, which is replaced by the rank ID.

Tell me if you prefer checking explicitely that the device node exists (with the access call), or you prefer updating the failure message at rank allocation (telling that module might be obsolete).

And I do not know how you format the code?