### PR TITLE
dpu: llvm: Add support for EXTLOAD when emitting multiplications

### DIFF
--- a/llvm/lib/Target/DPU/DPUTargetLowering.cpp
+++ b/llvm/lib/Target/DPU/DPUTargetLowering.cpp
@@ -1229,6 +1229,10 @@ static bool isArgumentExtended(SDValue Op, MVT::SimpleValueType initialType,
         argCouldWork = true;
         isSigned = false;
         break;
+      case ISD::LoadExtType::EXTLOAD: {
+        argCouldWork = true;
+        isSigned = true;
+      } break;
       default:
         break;
       }


### PR DESCRIPTION
This patch addresses issue #59, and provides a partial fix that allows the compiler to emit hardware byte-wise multiplications. 

At the core, this issue is a result of LLVM's aggressive instruction combiner/eliminator. Essentially, information about the signedness of a value in LLVM IR is stored through the use of casts such as `zext` which specifies that the type is "zero extended" (for example) to some other larger type. If LLVM encounters a series of instructions that look like:

```
%conv = sext i8 %a to i32, !dbg !15
%conv1 = sext i8 %b to i32, !dbg !16
%mul = mul nsw i32 %conv, %conv1, !dbg !17
%conv2 = trunc i32 %mul to i8, !dbg !15
```

then the instruction combiner will notice that the final type (`i8`) is the same as the type of the inputs, and remove the extending casts and truncation so that the entire computation is done using `i8` values. 

This poses an issue, however, as the `zext` (or `sext`) casts are *sometimes* the only way in which signed-ness information is passed around the IR. Once this information has been lost, the only way that later stages of the compiler can emit load instructions is by marking them as "any extended" - i.e. extended, but without any particular signed-ness. 

Finally, as our architecture only supports 32bit (and 64bit, but that is irrelevant to this issue) registers, all values are converted to operate in 32-bits for the next stage of the compiler after LLVM IR. This is done by considering the kind of extension that was done earlier (i.e. zero, signed, or any), and attaching that information to the `load` instructions in this next stage of the compiler. When we finally process this in our backend, we must therefore include some logic to work out when our multiplications are operating on 32-bit values, or in 8-bit values that have been *extended* out to 32-bits. In our code that does this, unfortunately, we missed out on the `extload` case - and only handled `zextload` and `sextload`. This meant that in cases where we were extending, our backend incorrectly thought that the values were *originally* 32-bits, rather than extended 8-bit values, and simply emitted a software multiply.

This patch fixes this issue by *also* handling the `extload` option. As we have no information about signed-ness here, we simply default to emitting a signed multiplication. This may be incorrect, depending on the semantic differences between signed and unsigned multiplication instructions, but as we have no other information we have to make a fixed decision.

This fix is "partial" insofar as the *real* issue resides in the "higher" pass that eliminates the signed-ness information. Fixing this however is beyond the scope of this bug, and may require some significant design work around the LLVM IR transforms and semantics as well as discussion with the wider LLVM community. Hence, as this fix is sufficient for the bug, it should be enough for now.