### PR TITLE
dpu: lldb: Explicitly read and transfer address of error_storage when…

### DIFF
--- a/lldb/scripts/dpu/dpu_commands.py
+++ b/lldb/scripts/dpu/dpu_commands.py
@@ -303,13 +303,6 @@ def dpu_attach(debugger, command, result, internal_dict):
             lldb_server_dpu_env["UPMEM_LLDB_NR_TASKLETS"] = \
                 str(nr_tasklets.GetIntegerValue())
 
-    subprocess.Popen(['lldb-server-dpu',
-                      'gdbserver',
-                      '--attach',
-                      str(pid),
-                      ':2066'],
-                     env=lldb_server_dpu_env)
-
     if program_path is not None and not os.path.exists(program_path):
         program_path = None
     target_dpu = \
@@ -318,6 +311,17 @@ def dpu_attach(debugger, command, result, internal_dict):
     if not(target_dpu.IsValid()):
         print("Could not create dpu target")
         return None
+
+    storage = target_dpu.FindFirstGlobalVariable("error_storage")
+    if storage.IsValid():
+        lldb_server_dpu_env["UPMEM_LLDB_ERROR_STORE_ADDR"] = str(storage.location)
+
+    subprocess.Popen(['lldb-server-dpu',
+                      'gdbserver',
+                      '--attach',
+                      str(pid),
+                      ':2066'],
+                     env=lldb_server_dpu_env)
 
     listener = debugger.GetListener()
     error = lldb.SBError()

--- a/lldb/scripts/dpu/dpu_commands.py
+++ b/lldb/scripts/dpu/dpu_commands.py
@@ -312,6 +312,11 @@ def dpu_attach(debugger, command, result, internal_dict):
         print("Could not create dpu target")
         return None
 
+    # Get the address of the error_storage variable.
+    # As we need to send this address *before* the lldb server has started we cannot send it as a
+    # normal lldb GDBRemote packet. Instead, we set an environment variable with the value that we
+    # have looked up from the loaded bianry. If we cannot find one, then this environment variable
+    # remains unset, and we cannot detach and re-attach within different processes.
     storage = target_dpu.FindFirstGlobalVariable("error_storage")
     if storage.IsValid():
         lldb_server_dpu_env["UPMEM_LLDB_ERROR_STORE_ADDR"] = str(storage.location)

--- a/lldb/source/Plugins/Process/Dpu/Dpu.cpp
+++ b/lldb/source/Plugins/Process/Dpu/Dpu.cpp
@@ -61,7 +61,7 @@ Dpu::Dpu(DpuRank *rank, dpu_t *dpu, FILE *stdout_file_, bool valid)
     : m_rank(rank), m_dpu(dpu), printf_enable(false),
       printf_buffer_last_idx((uint32_t)LLDB_INVALID_ADDRESS),
       printf_buffer_var_addr((uint32_t)LLDB_INVALID_ADDRESS),
-      error_store_addr((uint32_t)LLDB_INVALID_ADDRESS), m_valid(valid) {
+      error_store_addr((uint32_t)0 /*nullptr*/), m_valid(valid) {
   nr_threads = m_rank->GetNrThreads();
   nr_reg_per_thread = rank->GetDesc()->hw.dpu.nr_of_work_registers_per_thread;
 

--- a/lldb/source/Plugins/Process/Dpu/Dpu.cpp
+++ b/lldb/source/Plugins/Process/Dpu/Dpu.cpp
@@ -60,7 +60,8 @@ const uint32_t mram_aligned_mask = ~mram_aligned_mod;
 Dpu::Dpu(DpuRank *rank, dpu_t *dpu, FILE *stdout_file_, bool valid)
     : m_rank(rank), m_dpu(dpu), printf_enable(false),
       printf_buffer_last_idx((uint32_t)LLDB_INVALID_ADDRESS),
-      printf_buffer_var_addr((uint32_t)LLDB_INVALID_ADDRESS), m_valid(valid) {
+      printf_buffer_var_addr((uint32_t)LLDB_INVALID_ADDRESS),
+      error_store_addr((uint32_t)LLDB_INVALID_ADDRESS), m_valid(valid) {
   nr_threads = m_rank->GetNrThreads();
   nr_reg_per_thread = rank->GetDesc()->hw.dpu.nr_of_work_registers_per_thread;
 
@@ -116,6 +117,19 @@ bool Dpu::SetPrintfSequenceAddrsFromRuntimeInfo(dpu_program_t *runtime) {
   return true;
 }
 
+bool Dpu::SetErrorStoreAddr(const uint32_t _error_store_addr) {
+  error_store_addr = _error_store_addr;
+  return true;
+}
+
+bool Dpu::SetErrorStoreAddrFromRuntimeInfo(dpu_program_t *runtime) {
+  struct dpu_symbol_t dpu_error_storage;
+  if (dpu_get_symbol(runtime, "error_storage", &dpu_error_storage) != DPU_OK) {
+    return false;
+  }
+  return Dpu::SetErrorStoreAddr(dpu_error_storage.address);
+}
+
 bool Dpu::LoadElf(const FileSpec &elf_file_path) {
   ModuleSP elf_mod(new Module(elf_file_path, k_dpu_arch));
 
@@ -133,6 +147,9 @@ bool Dpu::LoadElf(const FileSpec &elf_file_path) {
     nr_threads = nr_threads_enabled;
 
   if (!SetPrintfSequenceAddrsFromRuntimeInfo(runtime))
+    return false;
+
+  if (!SetErrorStoreAddrFromRuntimeInfo(runtime))
     return false;
 
   return true;
@@ -203,7 +220,7 @@ bool Dpu::StopThreads(bool force) {
     return true;
   dpu_is_running = false;
 
-  return m_context->StopThreads();
+  return m_context->StopThreads(error_store_addr);
 }
 
 StateType Dpu::StepOverPrintfSequenceAndContinue(StateType result_state,

--- a/lldb/source/Plugins/Process/Dpu/Dpu.h
+++ b/lldb/source/Plugins/Process/Dpu/Dpu.h
@@ -47,6 +47,8 @@ public:
                               const uint32_t print_buffer_size,
                               const uint32_t print_var_addr);
   bool SetPrintfSequenceAddrsFromRuntimeInfo(dpu_program_t *runtime);
+  bool SetErrorStoreAddr(const uint32_t error_store_addr);
+  bool SetErrorStoreAddrFromRuntimeInfo(dpu_program_t *runtime);
 
   bool LoadElf(const FileSpec &elf_file_path);
   bool Boot();
@@ -123,6 +125,7 @@ private:
   dpuinstruction_t open_print_sequence_inst, close_print_sequence_inst;
   uint32_t printf_buffer_last_idx, printf_buffer_var_addr,
       printf_buffer_address, printf_buffer_size;
+  uint32_t error_store_addr;
   FILE *stdout_file;
   bool m_valid;
 };

--- a/lldb/source/Plugins/Process/Dpu/DpuContext.cpp
+++ b/lldb/source/Plugins/Process/Dpu/DpuContext.cpp
@@ -79,7 +79,7 @@ void DpuContext::UpdateRunningThreads() {
   }
 }
 
-bool DpuContext::StopThreads() {
+bool DpuContext::StopThreads(uint32_t error_store_addr) {
   ResetScheduling();
 
   m_context->bkp_fault = false;
@@ -87,7 +87,8 @@ bool DpuContext::StopThreads() {
   m_context->mem_fault = false;
 
   int ret = DPU_OK;
-  ret = dpu_initialize_fault_process_for_dpu(m_dpu, m_context);
+  ret =
+      dpu_initialize_fault_process_for_dpu(m_dpu, m_context, error_store_addr);
   if (ret != DPU_OK)
     return false;
   ret = dpu_extract_context_for_dpu(m_dpu, m_context);

--- a/lldb/source/Plugins/Process/Dpu/DpuContext.h
+++ b/lldb/source/Plugins/Process/Dpu/DpuContext.h
@@ -48,7 +48,7 @@ public:
 
   void UpdateContext(struct dpu_context_t *new_context);
 
-  bool StopThreads();
+  bool StopThreads(uint32_t error_store_addr);
   bool ResumeThreads(llvm::SmallVector<uint32_t, 8> *resume_list);
   dpu_error_t StepThread(uint32_t thread_index);
 

--- a/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp
+++ b/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp
@@ -213,6 +213,11 @@ ProcessDpu::Factory::Attach(
   if (nr_tasklets_ptr != NULL)
     dpu->SetNrThreads(::strtoll(nr_tasklets_ptr, NULL, 10));
 
+  char *error_store_addr_ptr = std::getenv("UPMEM_LLDB_ERROR_STORE_ADDR");
+
+  if (error_store_addr_ptr != NULL)
+    dpu->SetErrorStoreAddr(::strtol(error_store_addr_ptr, NULL, 16));
+
   success = rank->SaveContext();
   if (!success)
     return Status("Cannot save the rank context ").ToError();


### PR DESCRIPTION
… attaching to dpu

This PR adds support for repeated attaching and detaching from a DPU in fault, by reading the address of the `error_storage` variable from the provided program, and passing that through lldb in to the debug layer of the runtime. 

This PR, along with the backend changes in #282 (https://github.com/upmem/backends/pull/282) fixes backend issue #268 (https://github.com/upmem/backends/issues/268).