### PR TITLE
dpu: lldb: added new error (Wrong MRAM unaligned access)

### DIFF
--- a/lldb/source/Plugins/Process/Dpu/Dpu.cpp
+++ b/lldb/source/Plugins/Process/Dpu/Dpu.cpp
@@ -749,9 +749,15 @@ bool *Dpu::ThreadRegistersHasBeenModified() {
   return &registers_has_been_modified;
 }
 
-const std::string bkp_fault_description[8] = {
-    "",     "Heap Full",       "Division by Zero",  "Assert",
-    "Halt", "Printf Overflow", "Already Profiling", "Not Profiling"};
+const std::string bkp_fault_description[9] = {"",
+                                              "Heap Full",
+                                              "Division by Zero",
+                                              "Assert",
+                                              "Halt",
+                                              "Printf Overflow",
+                                              "Already Profiling",
+                                              "Not Profiling",
+                                              "Wrong Alignment"};
 
 lldb::StateType Dpu::GetThreadState(uint32_t thread_index,
                                     std::string &description,


### PR DESCRIPTION
This pull request is related to the development of a new feature in the DPU runtime library: the possibility to perform unaligned MRAM accesses under certain conditions. One of the condition is that the WRAM buffer has the same alignment than the MRAM address (write to MRAM case). If this condition is not respected, a new DPU fault is generated. The change in this pull request is for the debugger to correctly display the reason for this new error ("Wrong alignment"). 