### PR TITLE
dpu: llvm: fix type in DPUInstrInfo.td

### DIFF
--- a/llvm/lib/Target/DPU/DPUInstrInfo.td
+++ b/llvm/lib/Target/DPU/DPUInstrInfo.td
@@ -130,7 +130,7 @@ def IsInImmediateSection: PatFrag<(ops node:$sym), (DPUWrapper node:$sym), [{
     return IsGlobalAddrInImmediateSection(N);
 }]>;
 
-multiclass WramLoadXPat<ImmOperand LdTy, PatFrag LoadOp, DPUInstruction Inst> {
+multiclass WramLoadXPat<ValueType LdTy, PatFrag LoadOp, DPUInstruction Inst> {
   def : Pat<(LdTy (wram_load_frag<LoadOp> SimpleRegOrCst:$ra)), (Inst SimpleRegOrCst:$ra, 0)>;
   def : Pat<(LdTy (wram_load_frag<LoadOp> AddrFI:$ra)), (Inst AddrFI:$ra, 0)>;
   def : Pat<(LdTy (wram_load_frag<LoadOp> (DPUWrapper i32:$off))), (Inst ZERO, i32:$off)>;
@@ -149,7 +149,7 @@ multiclass WramLoadPat<PatFrag LoadOp, DPUInstruction Inst, DPUInstruction Inst6
     defm : WramLoadXPat<i64, LoadOp, Inst64>;
 }
 
-multiclass WramStorePat<PatFrag StoreOp, DPUInstruction Inst, RegisterClass StTy> {
+multiclass WramStorePat<PatFrag StoreOp, DPUInstruction Inst, DPURegOperand StTy> {
   def : Pat<(wram_store_frag<StoreOp> StTy:$rb, SimpleRegOrCst:$ra), (Inst SimpleRegOrCst:$ra, 0, StTy:$rb)>;
   def : Pat<(wram_store_frag<StoreOp> StTy:$rb, AddrFI:$ra), (Inst AddrFI:$ra, 0, StTy:$rb)>;
   def : Pat<(wram_store_frag<StoreOp> StTy:$rb, (DPUWrapper i32:$off)), (Inst ZERO, i32:$off, StTy:$rb)>;


### PR DESCRIPTION
Newer LLVM have stronger typing for compiling td files.

This patch fix these issues:

```
Included from /home/wwolff/work/dpu_tools_upgrade_by_rebase/llvm-project/llvm/lib/Target/DPU/DPU.td:17:
/home/wwolff/work/dpu_tools_upgrade_by_rebase/llvm-project/llvm/lib/Target/DPU/DPUInstrInfo.td:148:12: error: Value specified for template argument 'WramLoadXPat::LdTy' (#0) is of type ValueType; expected type ImmOperand: i32
    defm : WramLoadXPat<i32, LoadOp, Inst>;
           ^
```
In this case, the first parameter could be either `i32` or `i64` type, which are native LLVM `ValueType`


```
Included from /home/wwolff/work/dpu_tools_upgrade_by_rebase/llvm-project/llvm/lib/Target/DPU/DPU.td:17:
/home/wwolff/work/dpu_tools_upgrade_by_rebase/llvm-project/llvm/lib/Target/DPU/DPUInstrInfo.td:202:8: error: Value specified for template argument 'WramStorePat::StTy' (#2) is of type DPURegOperand; expected type RegisterClass: SimpleReg
defm : WramStorePat<truncstorei8, SBrir, SimpleReg>;
       ^
```
In this case, the last parameter is our defined DPU operand, hence it requires specialization.