### PR TITLE
dpu: llvm: lldb: dpu_commands.py: add dpu_attach_first helper

### DIFF
--- a/lldb/scripts/dpu/lldb_init_dpu_commands
+++ b/lldb/scripts/dpu/lldb_init_dpu_commands
@@ -3,3 +3,4 @@ command script add -f dpu_commands.dpu_attach dpu_attach
 command script add -f dpu_commands.dpu_list dpu_list
 command script add -f dpu_commands.dpu_attach_on_boot dpu_attach_on_boot
 command script add -f dpu_commands.dpu_detach dpu_detach
+command script add -f dpu_commands.dpu_attach_first dpu_attach_first


### PR DESCRIPTION
When an user want to attach to a DPU for debugging, it requires to retrieve the list of allocated DPUs for its particular session with `dpu_list -v`. Then it calls the `dpu_attach` function with the first entry of the list. This is somewhat painful.

In another scenarion, when the first allocated DPU is not `0.0.0`, the CI/CD test regression does not work as expected.

This commit add an helper to attach to the very first allocated DPU.