### PR TITLE
dpu: llvm & clang: remove builtin dpu_seqread_get

### DIFF
--- a/clang/include/clang/Basic/BuiltinsDPU.def
+++ b/clang/include/clang/Basic/BuiltinsDPU.def
@@ -17,6 +17,5 @@
 BUILTIN(__builtin_dpu_tid, "UiC", "nc")
 BUILTIN(__builtin_dpu_sdma, "vvC*v*Ui", "")
 BUILTIN(__builtin_dpu_ldma, "vv*vC*Ui", "")
-BUILTIN(__builtin_dpu_seqread_get, "iiUiv*UiC", "")
 
 #undef BUILTIN

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -17372,17 +17372,6 @@ Value *CodeGenFunction::EmitDPUBuiltinExpr(unsigned BuiltinID,
     Value *Arg2 = EmitScalarExpr(E->getArg(2));
     return Builder.CreateCall(Callee, {Arg0, Arg1, Arg2});
   }
-  case DPU::BI__builtin_dpu_seqread_get: {
-    llvm::Type *ResultType = ConvertType(E->getType());
-    Value *ArgPtr = EmitScalarExpr(E->getArg(0));
-    Value *ArgInc = EmitScalarExpr(E->getArg(1));
-    Value *ArgReader = EmitPointerWithAlignment(E->getArg(2)).getPointer();
-    Value *ArgPageSize = EmitScalarExpr(E->getArg(3));
-
-    llvm::Function *Callee =
-        CGM.getIntrinsic(Intrinsic::dpu_seqread_get, ResultType);
-    return Builder.CreateCall(Callee, {ArgPtr, ArgInc, ArgReader, ArgPageSize});
-  }
 
   default:
     return nullptr;

--- a/llvm/include/llvm/IR/IntrinsicsDPU.td
+++ b/llvm/include/llvm/IR/IntrinsicsDPU.td
@@ -22,6 +22,4 @@ def int_dpu_ldma : Intrinsic<[], [llvm_wram_ptr_ty, llvm_mram_ptr_ty, llvm_i32_t
 def int_dpu_sdma_unchecked : Intrinsic<[], [llvm_wram_ptr_ty, llvm_wram_ptr_ty, llvm_i32_ty], [IntrHasSideEffects, ReadOnly<ArgIndex<0>>, WriteOnly<ArgIndex<1>>, Throws]>;
 def int_dpu_ldma_unchecked : Intrinsic<[], [llvm_wram_ptr_ty, llvm_wram_ptr_ty, llvm_i32_ty], [IntrHasSideEffects, ReadOnly<ArgIndex<1>>, WriteOnly<ArgIndex<0>>, Throws]>;
 
-def int_dpu_seqread_get : Intrinsic<[llvm_anyint_ty], [llvm_i32_ty, llvm_i32_ty, llvm_ptr_ty, llvm_i32_ty], [IntrHasSideEffects]>;
-
 }

--- a/llvm/lib/Target/DPU/DPUISelLowering.h
+++ b/llvm/lib/Target/DPU/DPUISelLowering.h
@@ -157,9 +157,6 @@ enum {
   LDMA,
   SDMA,
 
-  SEQREAD_GET,
-  SEQREAD_GET_CST,
-
   LHU_BIG,
   LHS_BIG,
   LW_BIG,

--- a/llvm/lib/Target/DPU/DPUInstrInfo.td
+++ b/llvm/lib/Target/DPU/DPUInstrInfo.td
@@ -58,10 +58,6 @@ def SDT_DMA  : SDTypeProfile<0, 3, [SDTCisInt<2>, SDTCisVT<0, iPTR>, SDTCisVT<1,
 def SDT_Ldma : SDNode<"DPUISD::LDMA", SDT_DMA, [SDNPHasChain]>;
 def SDT_Sdma : SDNode<"DPUISD::SDMA", SDT_DMA, [SDNPHasChain]>;
 
-def SDT_SEQREAD_GET : SDTypeProfile<1, 5, [SDTCisInt<0>, SDTCisInt<1>, SDTCisVT<2, iPTR>, SDTCisInt<3>, SDTCisInt<4>]>;
-def DPUSeqreadGet : SDNode<"DPUISD::SEQREAD_GET", SDT_SEQREAD_GET, [SDNPHasChain]>;
-def DPUSeqreadGetCst : SDNode<"DPUISD::SEQREAD_GET_CST", SDT_SEQREAD_GET, [SDNPHasChain]>;
-
 // To promote special types of operands to registers (see the patterns below).
 def SDTDPUWrapper       : SDTypeProfile<1, 1, [SDTCisSameAs<0, 1>, SDTCisPtrTy<0>]>;
 def DPUWrapper          : SDNode<"DPUISD::Wrapper", SDTDPUWrapper>;
@@ -76,20 +72,6 @@ def DPULwBig : SDNode <"DPUISD::LW_BIG", SDT_DPULoadBig, [SDNPHasChain, SDNPMayL
 def DPULdBig : SDNode <"DPUISD::LD_BIG", SDT_DPULoadBig, [SDNPHasChain, SDNPMayLoad]>;
 
 include "DPUInstrFormats.td"
-
-let usesCustomInserter = 1 in {
-def SEQREAD_GET: PseudoDPUInstruction<
-    (outs SimpleReg:$rc),
-    (ins SimpleReg:$ptr, SimpleReg:$inc, SimpleReg:$reader, i32imm:$cc, i32imm:$pageSize),
-    "",
-    [(set i32:$rc, (DPUSeqreadGet i32:$ptr, i32:$inc, i32:$reader, (i32 imm:$cc), (i32 imm:$pageSize)))]>;
-
-def SEQREAD_GET_CST: PseudoDPUInstruction<
-    (outs SimpleReg:$rc),
-    (ins SimpleReg:$ptr, s8_imm:$inc, SimpleReg:$reader, i32imm:$cc, i32imm:$pageSize),
-    "",
-    [(set i32:$rc, (DPUSeqreadGetCst i32:$ptr, (s8_imm:$inc), i32:$reader, (i32 imm:$cc), (i32 imm:$pageSize)))]>;
-}
 
 def ADD_VAStart: PseudoDPUInstruction<
                     (outs SimpleReg:$rc), (ins SimpleReg:$ra),

--- a/llvm/lib/Target/DPU/DPUTargetLowering.h
+++ b/llvm/lib/Target/DPU/DPUTargetLowering.h
@@ -121,8 +121,6 @@ private:
 
   SDValue LowerDMA(SDValue Op, SelectionDAG &DAG, int DPUISD) const;
 
-  SDValue LowerSeqreadGet(SDValue Op, SelectionDAG &DAG) const;
-
   SDValue LowerIntrinsic(SDValue Op, SelectionDAG &DAG,
                          int IntrinsicType) const;
 


### PR DESCRIPTION
The builtin lowering is ill-formed with arithmetic+comp+branch instruction. Emit a splitted version in EmitInstrWithCustomInserter to recombine later is too complicated.

This commit revert to what it was before, a simple function call in the runtime library.

This revert the followings:

"dpu: llvm: seqread_get: force incr to be a positive signed char to be optimized" This reverts commit cfc4828eb3353de1d874dbb0dd064e71151b5ba0

"dpu: llvm: enumerate every nc condition to convert pageSizeLog2" This reverts commit 3c67e43bf16b25ab8060ae01f793abb993a1c856.

"dpu: llvm & clang: add builtin dpu_seqread_get"
This reverts commit 301a2e2b9eafc8260a61aec8096fc1fc2e9803c7