### PR TITLE
dev/wwolff/optimize_mram_write

### DIFF
--- a/lldb/source/Plugins/Process/Dpu/Dpu.h
+++ b/lldb/source/Plugins/Process/Dpu/Dpu.h
@@ -110,6 +110,9 @@ public:
   lldb::addr_t GetClosePrintfSequenceAddr();
 
 private:
+  bool WriteWRAMHandlingAlignment(uint32_t offset, const void *buf, size_t size);
+  bool WriteMRAMHandlingAlignment(uint32_t offset, const void *buf, size_t size);
+
   bool WriteIRAMUntraced(uint32_t offset, const void *buf, size_t size);
 
   DpuRank *m_rank;

--- a/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp
+++ b/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp
@@ -614,24 +614,29 @@ Status ProcessDpu::ReadMemory(lldb::addr_t addr, void *buf, size_t size,
 
   bytes_read = 0;
   switch (ComputeMemoryAddressSpace(addr, size)) {
-  case eMemoryAddressSpaceIRAM:
+  case eMemoryAddressSpaceIRAM: {
     if (!m_dpu->ReadIRAM(addr - k_dpu_iram_base, buf, size))
       return Status("ReadMemory: Cannot copy from IRAM");
     break;
+  }
 
-  case eMemoryAddressSpaceMRAM:
+  case eMemoryAddressSpaceMRAM: {
     if (!m_dpu->ReadMRAM(addr - k_dpu_mram_base, buf, size))
       return Status("ReadMemory: Cannot copy from MRAM");
     break;
+  }
 
-  case eMemoryAddressSpaceWRAM:
+  case eMemoryAddressSpaceWRAM: {
     if (!m_dpu->ReadWRAM(addr, buf, size))
       return Status("ReadMemory: Cannot copy from WRAM");
     break;
+  }
 
-  case eMemoryAddressSpaceUNKNOWN:
+  case eMemoryAddressSpaceUNKNOWN: {
     return Status("ReadMemory: Cannot read, unknown address space");
   }
+  }
+
   bytes_read = size;
 
   return Status();
@@ -644,24 +649,29 @@ Status ProcessDpu::WriteMemory(lldb::addr_t addr, const void *buf, size_t size,
 
   bytes_written = 0;
   switch (ComputeMemoryAddressSpace(addr, size)) {
-  case eMemoryAddressSpaceIRAM:
+  case eMemoryAddressSpaceIRAM: {
     if (!m_dpu->WriteIRAM(addr - k_dpu_iram_base, buf, size))
       return Status("WriteMemory: Cannot copy to IRAM");
     break;
+  }
 
-  case eMemoryAddressSpaceMRAM:
+  case eMemoryAddressSpaceMRAM: {
     if (!m_dpu->WriteMRAM(addr - k_dpu_mram_base, buf, size))
       return Status("WriteMemory: Cannot copy to MRAM");
     break;
+  }
 
-  case eMemoryAddressSpaceWRAM:
+  case eMemoryAddressSpaceWRAM: {
     if (!m_dpu->WriteWRAM(addr, buf, size))
       return Status("WriteMemory: Cannot copy to WRAM");
     break;
+  }
 
-  case eMemoryAddressSpaceUNKNOWN:
+  case eMemoryAddressSpaceUNKNOWN: {
     return Status("WriteMemory: Cannot write, unknown address space");
   }
+  }
+
   bytes_written = size;
 
   return Status();


### PR DESCRIPTION
Writing to MRAM is quite tedious in the sense that address and size to MRAM must be aligned to 8 bytes.

Currently in LLDB, when writing, if address or size doesn't align to 8 bytes, we are reading the entire destination space with the constraint, and use some sort of masked data modification to finally rewrite the entire buffer back to the MRAM.

For example, taking `seqreader_example` regression test:

```
30: (lldb) memory write -i sample.bin `&buffer[0]`
30: 
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:642:WriteMemory(134217728, 0x55dc9e193400, 65501, )
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:621:WriteMRAM(0, 0x55dc9e193400, 65501)
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:622:WriteMRAM offset rem = 0, size rem = 5
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:642:WriteMRAM slow path final_offset = 0, padding = 0, final_size = 65504
30: 
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:642:WriteMemory(134283229, 0x55dc9e144160, 39, )
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:621:WriteMRAM(65501, 0x55dc9e144160, 39)
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:622:WriteMRAM offset rem = 5, size rem = 7
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:642:WriteMRAM slow path final_offset = 65496, padding = 5, final_size = 48
30: 65540 bytes were written to 0x8000000
```

LLDB internally dissect the write of 65540 bytes into two write of 65501 + 39 bytes.
Both LLDB write operation are not aligned. So in this case, we read 65504 + 48 from MRAM, update the buffer, and then write this same amount of data back to MRAM.


This patch implements a different approach by advancing the beggining and cropping the end to align them to 8 bytes, to then write a big aligned block.
On the same example as above, we only read 8 + 8 + 8 bytes for the alignement.

```
30: (lldb) memory write -i sample.bin `&buffer[0]`
30: 
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:642:WriteMemory(134217728, 0x56005774b3e0, 65501, )
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:660:WriteMemory locationInMRAM = 0
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:680:WriteMemory cropping sizeToAlignSize = 5
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:621:WriteMRAM(65496, 0x56005775b3b8, 5)
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:622:WriteMRAM offset rem = 0, size rem = 5
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:642:WriteMRAM slow path final_offset = 65496, padding = 0, final_size = 8
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:688:WriteMemory new size = 65496
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:691:WriteMemory big aligned block locationInMRAM = 0, size = 65496
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:621:WriteMRAM(0, 0x56005774b3e0, 65496)
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:622:WriteMRAM offset rem = 0, size rem = 0
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:631:WriteMRAM return fast path
30: 
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:642:WriteMemory(134283229, 0x5600576fc160, 39, )
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:660:WriteMemory locationInMRAM = 65501
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:667:WriteMemory advancing offsetToAlignLocation = 3
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:621:WriteMRAM(65501, 0x5600576fc160, 3)
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:622:WriteMRAM offset rem = 5, size rem = 3
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:642:WriteMRAM slow path final_offset = 65496, padding = 5, final_size = 8
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:673:WriteMemory new locationInMRAM = 65504
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:674:WriteMemory new size = 36
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:680:WriteMemory cropping sizeToAlignSize = 4
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:621:WriteMRAM(65536, 0x5600576fc183, 4)
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:622:WriteMRAM offset rem = 0, size rem = 4
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:642:WriteMRAM slow path final_offset = 65536, padding = 0, final_size = 8
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:688:WriteMemory new size = 32
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:691:WriteMemory big aligned block locationInMRAM = 65504, size = 32
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:621:WriteMRAM(65504, 0x5600576fc163, 32)
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:622:WriteMRAM offset rem = 0, size rem = 0
30: ../../../../../work/dpu_tools/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:631:WriteMRAM return fast path
30: 65540 bytes were written to 0x8000000
```


Here is another example, exhibing the similar change on WRAM writing:
```
(lldb) memory write -i sample.bin `&buffer[2]`

../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:647:WriteMemory(450, 0x55d2f338df60, 19, )
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:448:WriteWRAMTreatingAlignement(450, 0x55d2f338df60, 19)
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:449:WriteWRAMTreatingAlignement offset rem = 2, size rem = 3
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:475:WriteWRAMTreatingAlignement slow path final_offset_in_dpuword = 112, padding = 2, final_size_in_dpuword = 6
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:502:WriteWRAMTreatingAlignement return res = 0
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:678:WriteMemory bytes_written 19
19 bytes were written to 0x1c2
(lldb) memory write -i sample.bin `&buffer_mram[2]`

../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:647:WriteMemory(134217730, 0x55d2f338df60, 19, )
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:673:WriteMRAMTreatingAlignement(2, 0x55d2f338df60, 19)
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:674:WriteMRAMTreatingAlignement offset rem = 2, size rem = 3
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:694:WriteMRAMTreatingAlignement slow path final_offset = 0, padding = 2, final_size = 24
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:716:WriteMRAMTreatingAlignement return res = 0
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:678:WriteMemory bytes_written 19
19 bytes were written to 0x8000002
```
vs

```
(lldb) memory write -i sample.bin `&buffer[2]`                                                                                                                                                                      
                                                                                                                                                                                                                    
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:647:WriteMemory(450, 0x562d26032f60, 19, )
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:508:WriteWRAM locationInWRAM = 450                     
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:515:WriteWRAM advancing offsetToAlignLocation = 2
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:448:WriteWRAMTreatingAlignement(450, 0x562d26032f60, 2)
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:449:WriteWRAMTreatingAlignement offset rem = 2, size rem = 2
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:475:WriteWRAMTreatingAlignement slow path final_offset_in_dpuword = 112, padding = 2, final_size_in_dpuword = 1
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:502:WriteWRAMTreatingAlignement return res = 0
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:521:WriteWRAM new locationInWRAM = 452
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:522:WriteWRAM new size = 17
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:528:WriteWRAM cropping sizeToAlignSize = 1
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:448:WriteWRAMTreatingAlignement(468, 0x562d26032f72, 1)
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:449:WriteWRAMTreatingAlignement offset rem = 0, size rem = 1
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:475:WriteWRAMTreatingAlignement slow path final_offset_in_dpuword = 117, padding = 0, final_size_in_dpuword = 1
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:502:WriteWRAMTreatingAlignement return res = 0
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:536:WriteWRAM new size = 16
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:539:WriteWRAM big aligned block locationInWRAM = 452, size = 16
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:448:WriteWRAMTreatingAlignement(452, 0x562d26032f62, 16)
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:449:WriteWRAMTreatingAlignement offset rem = 0, size rem = 0
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:460:WriteWRAMTreatingAlignement return fast path
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:678:WriteMemory bytes_written 19
19 bytes were written to 0x1c2
(lldb) memory write -i sample.bin `&buffer_mram[2]`

../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:647:WriteMemory(134217730, 0x562d26032f60, 19, )
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:721:WriteMRAM locationInMRAM = 2
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:727:WriteMRAM advancing offsetToAlignLocation = 6
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:672:WriteMRAMTreatingAlignement(2, 0x562d26032f60, 6)
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:673:WriteMRAMTreatingAlignement offset rem = 2, size rem = 6
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:693:WriteMRAMTreatingAlignement slow path final_offset = 0, padding = 2, final_size = 8
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:715:WriteMRAMTreatingAlignement return res = 0
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:733:WriteMRAM new locationInMRAM = 8
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:734:WriteMRAM new size = 13
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:740:WriteMRAM cropping sizeToAlignSize = 5
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:672:WriteMRAMTreatingAlignement(16, 0x562d26032f6e, 5)
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:673:WriteMRAMTreatingAlignement offset rem = 0, size rem = 5
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:693:WriteMRAMTreatingAlignement slow path final_offset = 16, padding = 0, final_size = 8
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:715:WriteMRAMTreatingAlignement return res = 0
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:748:WriteMRAM new size = 8
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:751:WriteMRAM big aligned block locationInMRAM = 8, size = 8
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:672:WriteMRAMTreatingAlignement(8, 0x562d26032f66, 8)
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:673:WriteMRAMTreatingAlignement offset rem = 0, size rem = 0
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/Dpu.cpp:682:WriteMRAMTreatingAlignement return fast path
../../../../../work/dpu_tools_optimize_mram_write/llvm-project/lldb/source/Plugins/Process/Dpu/ProcessDpu.cpp:678:WriteMemory bytes_written 19
19 bytes were written to 0x8000002
```